### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 koa2-boilerplate
 ====
 
-![MIT](https://img.shields.io/npm/l/express.svg) ![node version](https://img.shields.io/badge/node-v6.3.0-green.svg) [![docker build](https://img.shields.io/docker/automated/superalsrk/koa2-boilerplate.svg)](https://hub.docker.com/r/superalsrk/koa2-boilerplate/builds/)
+![MIT](https://img.shields.io/npm/l/express.svg) ![node version](https://img.shields.io/badge/node-v6.3.0-green.svg) [![docker build](https://img.shields.io/docker/automated/superalsrk/koa2-boilerplate.svg)](https://hub.docker.com/r/superalsrk/koa2-boilerplate/builds/) [![](https://images.microbadger.com/badges/image/superalsrk/koa2-boilerplate.svg)](https://microbadger.com/images/superalsrk/koa2-boilerplate "Get your own image badge on microbadger.com")
 
 This boilerplate shows ways to 
 
@@ -60,3 +60,4 @@ $ docker run -d -p 5000:5000 superalsrk/koa2-boilerplate
 MIT
 
 
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [superalsrk/koa2-boilerplate](https://hub.docker.com/r/superalsrk/koa2-boilerplate/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/superalsrk/koa2-boilerplate).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/superalsrk/koa2-boilerplate.svg)](https://microbadger.com/images/superalsrk/koa2-boilerplate)
